### PR TITLE
Bug fixing both time being displayed, and author not being displayed

### DIFF
--- a/mainpage.py
+++ b/mainpage.py
@@ -152,7 +152,7 @@ def edit(id):
     to_edit = poster.query.get_or_404(id)
     if request.method == 'POST':
         to_edit.title = request.form['title']
-        to_edit.author = request.form['author']
+        to_edit.posted_by = request.form['author']
         to_edit.content = request.form['post']
         db.session.commit()
         return redirect('/posts')

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -13,7 +13,7 @@
     <br>
     <label for="content">Author:</label>
     <input class="form-control" type="text" name="author" id="author"
-        value="{{post.author}}">
+        value="{{post.posted_by}}">
     <br>
     <label for="post">Post:</label>
     <textarea class="form-control" id="post" name="post" rows="3">{{post.content}}</textarea>


### PR DESCRIPTION
- Edited post.html by editing name of "post.author" to "post.posted_by" to display the author of posts, and to display time differently through legal format codes (https://www.w3schools.com/python/python_datetime.asp for legal format codes and https://www.pythonprogramming.in/python-print-current-time-with-am-pm.html as example for multiple legal format codes)
- Time is listed in UTC, but it might be 1-2 min. off when posting a new post
- Edited edit.html by changing post.author to posted_by to fill in who posted the post (if any was previously filled) when editing a post
- Edited mainpage.py by changing some lines (or one, I forgot how many) of code from "author" to "posted.by"

One bug I am concerned of, when you enter a post with a title that is the same as a post that already has that same title, the website will crash. I can bring it up next meeting (10/29) to discuss it.